### PR TITLE
plugins: Let plugins return errors while fetching username

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-system-settings-online-accounts (0.9~0ubports1) xenial; urgency=medium
+
+  * debian/changelog: new versioning scheme
+  * Allow plugin to cancel asynchronous username retrieval
+
+ -- Alberto Mardegan <mardy@users.sourceforge.net>  Wed, 19 Sep 2018 18:14:52 +0300
+
 ubuntu-system-settings-online-accounts (0.8+ubports) xenial; urgency=medium
 
   * Imported to UBports

--- a/plugins/module/OAuth.qml
+++ b/plugins/module/OAuth.qml
@@ -257,8 +257,13 @@ Item {
             return
         }
 
-        var userName = getUserName(reply, function(name) {
-            __gotUserName(name, reply)
+        var userName = getUserName(reply, function(name, error) {
+            if (error) {
+                console.warn("Error while getting username: " + error)
+                cancel()
+            } else {
+                __gotUserName(name, reply)
+            }
         })
         if (typeof(userName) == "string") {
             __gotUserName(userName, reply)


### PR DESCRIPTION
If an error occurs in the plugin while it's asynchronously fetching the
username, the UOA service is not notified and continues waiting forever.

Add an error parameter that plugins can use when invoking the callback
on error cases.