### PR TITLE
Destructive Button in Red

### DIFF
--- a/plugins/module/RemovalConfirmation.qml
+++ b/plugins/module/RemovalConfirmation.qml
@@ -36,6 +36,7 @@ Dialog {
 
     Button {
         text: i18n.dtr("ubuntu-system-settings-online-accounts", "Remove")
+        color: UbuntuColors.red
         onClicked: setConfirmed(true)
     }
 


### PR DESCRIPTION
When removing an online accounts, on the confirmation:
- Remove button in red (destructive action)