### PR TITLE
Add LoopbackServer and ExternalBrowserRequest classes

### DIFF
--- a/online-accounts-ui/external-browser-request.cpp
+++ b/online-accounts-ui/external-browser-request.cpp
@@ -1,0 +1,204 @@
+/*
+ * This file is part of online-accounts-ui
+ *
+ * Copyright (C) 2021 UBports Foundation
+ *
+ * Contact: Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "external-browser-request.h"
+
+#include "debug.h"
+#include "dialog.h"
+#include "globals.h"
+#include "i18n.h"
+
+#include <OnlineAccountsPlugin/request-handler.h>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QVariant>
+#include <SignOn/uisessiondata.h>
+#include <SignOn/uisessiondata_priv.h>
+
+using namespace SignOnUi;
+
+namespace SignOnUi {
+
+class ExternalBrowserRequestPrivate: public QObject
+{
+    Q_OBJECT
+    Q_DECLARE_PUBLIC(ExternalBrowserRequest)
+    Q_PROPERTY(QString title READ title CONSTANT)
+    Q_PROPERTY(QUrl startUrl READ startUrl CONSTANT)
+
+public:
+    ExternalBrowserRequestPrivate(ExternalBrowserRequest *request);
+    ~ExternalBrowserRequestPrivate();
+
+    void start();
+
+    QString title() const { return q_ptr->windowTitle(); }
+    QUrl startUrl() const { return m_startUrl; }
+
+public Q_SLOTS:
+    /* This method must be called when the final URL has been visited.
+     * Typically, a client should have setup a LoopbackServer on localhost, and
+     * forward the URL from the LoopbackServer::visited() signal to this slot.
+     */
+    void urlVisited(const QUrl &url);
+    void cancel();
+
+private Q_SLOTS:
+    void onFinished();
+
+private:
+    void buildDialog(const QVariantMap &params);
+    void closeView();
+
+private:
+    Dialog *m_dialog;
+    QUrl m_startUrl;
+    QUrl m_responseUrl;
+    mutable ExternalBrowserRequest *q_ptr;
+};
+
+} // namespace
+
+ExternalBrowserRequestPrivate::ExternalBrowserRequestPrivate(ExternalBrowserRequest *request):
+    QObject(request),
+    m_dialog(0),
+    q_ptr(request)
+{
+}
+
+ExternalBrowserRequestPrivate::~ExternalBrowserRequestPrivate()
+{
+    DEBUG();
+    closeView();
+    delete m_dialog;
+}
+
+void ExternalBrowserRequestPrivate::start()
+{
+    Q_Q(ExternalBrowserRequest);
+
+    const QVariantMap &params = q->parameters();
+    DEBUG() << params;
+
+    m_startUrl = params.value(SSOUI_KEY_OPENURL).toString();
+    if (!q->hasHandler()) {
+        buildDialog(params);
+
+        QObject::connect(m_dialog, SIGNAL(finished(int)),
+                         this, SLOT(onFinished()));
+
+        m_dialog->engine()->addImportPath(PLUGIN_PRIVATE_MODULE_DIR);
+        m_dialog->rootContext()->setContextProperty("request", this);
+        m_dialog->setSource(QUrl("qrc:/qml/SignOnUiPage.qml"));
+    } else {
+        DEBUG() << "Setting request on handler";
+        q->handler()->setRequest(this);
+    }
+}
+
+void ExternalBrowserRequestPrivate::urlVisited(const QUrl &url)
+{
+    DEBUG() << "Url visited:" << url;
+
+    m_responseUrl = url;
+    onFinished();
+}
+
+void ExternalBrowserRequestPrivate::cancel()
+{
+    Q_Q(ExternalBrowserRequest);
+
+    DEBUG() << "Client requested to cancel";
+    q->setCanceled();
+    closeView();
+}
+
+void ExternalBrowserRequestPrivate::onFinished()
+{
+    Q_Q(ExternalBrowserRequest);
+
+    DEBUG() << "ExternalBrowser dialog closed";
+    QObject::disconnect(m_dialog, SIGNAL(finished(int)),
+                        this, SLOT(onFinished()));
+
+    QVariantMap reply;
+    reply[SSOUI_KEY_URLRESPONSE] = m_responseUrl.toString();
+
+    closeView();
+
+    q->setResult(reply);
+}
+
+void ExternalBrowserRequestPrivate::buildDialog(const QVariantMap &params)
+{
+    m_dialog = new Dialog;
+
+    QString title;
+    if (params.contains(SSOUI_KEY_TITLE)) {
+        title = params[SSOUI_KEY_TITLE].toString();
+    } else if (params.contains(SSOUI_KEY_CAPTION)) {
+        title = OnlineAccountsUi::_("Web authentication for %1",
+                                    SIGNONUI_I18N_DOMAIN).
+            arg(params[SSOUI_KEY_CAPTION].toString());
+    } else {
+        title = OnlineAccountsUi::_("Web authentication",
+                                    SIGNONUI_I18N_DOMAIN);
+    }
+
+    m_dialog->setTitle(title);
+
+    DEBUG() << "Dialog was built";
+}
+
+void ExternalBrowserRequestPrivate::closeView()
+{
+    Q_Q(ExternalBrowserRequest);
+
+    DEBUG();
+    if (q->hasHandler()) {
+        q->handler()->setRequest(0);
+    } else if (m_dialog) {
+        m_dialog->close();
+    }
+}
+
+ExternalBrowserRequest::ExternalBrowserRequest(
+        int id,
+        const QString &clientProfile,
+        const QVariantMap &parameters,
+        QObject *parent):
+    Request(id, clientProfile, parameters, parent),
+    d_ptr(new ExternalBrowserRequestPrivate(this))
+{
+}
+
+ExternalBrowserRequest::~ExternalBrowserRequest()
+{
+}
+
+void ExternalBrowserRequest::start()
+{
+    Q_D(ExternalBrowserRequest);
+
+    Request::start();
+    d->start();
+}
+
+#include "external-browser-request.moc"

--- a/online-accounts-ui/external-browser-request.h
+++ b/online-accounts-ui/external-browser-request.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of online-accounts-ui
+ *
+ * Copyright (C) 2021 UBports Foundation
+ *
+ * Contact: Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranties of
+ * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+ * PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SIGNON_UI_EXTERNAL_BROWSER_REQUEST_H
+#define SIGNON_UI_EXTERNAL_BROWSER_REQUEST_H
+
+#include "signonui-request.h"
+
+#include <QObject>
+#include <QScopedPointer>
+
+namespace SignOnUi {
+
+class ExternalBrowserRequestPrivate;
+
+class ExternalBrowserRequest: public Request
+{
+    Q_OBJECT
+
+public:
+    explicit ExternalBrowserRequest(int id,
+                                    const QString &clientProfile,
+                                    const QVariantMap &parameters,
+                                    QObject *parent = 0);
+    ~ExternalBrowserRequest();
+
+    // reimplemented virtual methods
+    void start();
+
+private:
+    QScopedPointer<ExternalBrowserRequestPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(ExternalBrowserRequest)
+};
+
+} // namespace
+
+#endif // SIGNON_UI_EXTERNAL_BROWSER_REQUEST_H

--- a/online-accounts-ui/online-accounts-ui.pro
+++ b/online-accounts-ui/online-accounts-ui.pro
@@ -46,6 +46,7 @@ SOURCES += \
     debug.cpp \
     dialog.cpp \
     dialog-request.cpp \
+    external-browser-request.cpp \
     i18n.cpp \
     ipc.cpp \
     main.cpp \
@@ -60,6 +61,7 @@ HEADERS += \
     debug.h \
     dialog.h \
     dialog-request.h \
+    external-browser-request.h \
     i18n.h \
     ipc.h \
     provider-request.h \

--- a/plugins/OnlineAccountsPlugin/OnlineAccountsPlugin.pro
+++ b/plugins/OnlineAccountsPlugin/OnlineAccountsPlugin.pro
@@ -26,6 +26,7 @@ QMAKE_LFLAGS += $$QMAKE_LFLAGS_NOUNDEF
 private_headers += \
     account-manager.h \
     application-manager.h \
+    loopback-server.h \
     request-handler.h
 
 public_headers +=
@@ -36,6 +37,7 @@ INCLUDEPATH += \
 SOURCES += \
     account-manager.cpp \
     application-manager.cpp \
+    loopback-server.cpp \
     request-handler.cpp
 
 HEADERS += \

--- a/plugins/OnlineAccountsPlugin/loopback-server.cpp
+++ b/plugins/OnlineAccountsPlugin/loopback-server.cpp
@@ -1,0 +1,211 @@
+/*
+ * This file is part of libAuthentication
+ *
+ * Copyright (C) 2017-2020 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include "loopback-server.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QTcpServer>
+#include <QTcpSocket>
+
+using namespace OnlineAccountsPlugin;
+
+namespace OnlineAccountsPlugin {
+
+class LoopbackServerPrivate: public QTcpServer
+{
+    Q_OBJECT
+    Q_DECLARE_PUBLIC(LoopbackServer)
+
+public:
+    LoopbackServerPrivate(LoopbackServer *q);
+    ~LoopbackServerPrivate();
+
+    bool listen(uint16_t port);
+    void respond(QTcpSocket *socket);
+
+private Q_SLOTS:
+    void onNewConnection();
+    void onReadyRead();
+
+private:
+    int m_portIncrementAttempts;
+    QByteArray m_data;
+    QByteArray m_servedHtml;
+    LoopbackServer *q_ptr;
+};
+
+} // namespace
+
+LoopbackServerPrivate::LoopbackServerPrivate(LoopbackServer *q):
+    m_portIncrementAttempts(0),
+    q_ptr(q)
+{
+    QObject::connect(this, &QTcpServer::newConnection,
+                     this, &LoopbackServerPrivate::onNewConnection);
+
+    m_servedHtml =
+        QByteArrayLiteral("<html><head><title>") +
+        qApp->applicationName().toUtf8() +
+        QByteArrayLiteral("</title></head><body>") +
+        QObject::tr("Authentication completed; you can close this page "
+                    "and go back to the application.").
+        toUtf8() +
+        QByteArrayLiteral("</body></html>");
+}
+
+LoopbackServerPrivate::~LoopbackServerPrivate()
+{
+}
+
+bool LoopbackServerPrivate::listen(uint16_t port)
+{
+    uint16_t attempts = 0;
+
+    do {
+        bool ok = QTcpServer::listen(QHostAddress::Any,
+                                     quint16(port + attempts));
+        if (ok) return true;
+    } while (attempts++ < m_portIncrementAttempts);
+
+    return false;
+}
+
+void LoopbackServerPrivate::respond(QTcpSocket *socket)
+{
+    QByteArray htmlSize = QString::number(m_servedHtml.size()).toUtf8();
+    QByteArray replyMessage =
+        QByteArrayLiteral("HTTP/1.0 200 OK \r\n"
+                          "Content-Type: text/html; charset=\"utf-8\"\r\n"
+                          "Content-Length: ") + htmlSize +
+        QByteArrayLiteral("\r\n\r\n") +
+        m_servedHtml;
+
+    socket->write(replyMessage);
+}
+
+void LoopbackServerPrivate::onNewConnection()
+{
+    QTcpSocket *socket = nextPendingConnection();
+    Q_ASSERT(socket);
+    QObject::connect(socket, &QTcpSocket::disconnected,
+                     socket, &QTcpSocket::deleteLater);
+    QObject::connect(socket, &QTcpSocket::readyRead,
+                     this, &LoopbackServerPrivate::onReadyRead);
+}
+
+void LoopbackServerPrivate::onReadyRead()
+{
+    Q_Q(LoopbackServer);
+
+    QTcpSocket *socket = qobject_cast<QTcpSocket*>(sender());
+    Q_ASSERT(socket);
+
+    m_data += socket->readAll();
+    int lineLength = m_data.indexOf('\r');
+    if (lineLength < 0) {
+        /* Not all data has been received; will get more later */
+        return;
+    }
+    QByteArray firstLine = m_data.left(lineLength);
+    QList<QByteArray> parts = firstLine.split(' ');
+    if (parts.count() >= 2) {
+        QString path = QString::fromUtf8(parts[1]);
+        QUrl url(QString::fromLatin1("http://localhost:%1%2").
+                 arg(serverPort()).arg(path));
+        Q_EMIT q->visited(url);
+    }
+
+    respond(socket);
+    socket->disconnectFromHost();
+}
+
+LoopbackServer::LoopbackServer(QObject *parent):
+    QObject(parent),
+    d_ptr(new LoopbackServerPrivate(this))
+{
+}
+
+LoopbackServer::~LoopbackServer()
+{
+}
+
+bool LoopbackServer::listen(uint16_t port)
+{
+    Q_D(LoopbackServer);
+
+    bool ok = d->listen(port);
+
+    Q_EMIT callbackUrlChanged();
+
+    return ok;
+}
+
+void LoopbackServer::close()
+{
+    Q_D(LoopbackServer);
+    d->close();
+
+    Q_EMIT callbackUrlChanged();
+}
+
+uint16_t LoopbackServer::port() const
+{
+    Q_D(const LoopbackServer);
+    return d->serverPort();
+}
+
+void LoopbackServer::setPortIncrementAttempts(int maxAttempts)
+{
+    Q_D(LoopbackServer);
+    if (d->m_portIncrementAttempts == maxAttempts) return;
+    d->m_portIncrementAttempts = maxAttempts;
+    Q_EMIT portIncrementAttemptsChanged();
+}
+
+int LoopbackServer::portIncrementAttempts() const
+{
+    Q_D(const LoopbackServer);
+    return d->m_portIncrementAttempts;
+}
+
+void LoopbackServer::setServedHtml(const QByteArray &html)
+{
+    Q_D(LoopbackServer);
+    d->m_servedHtml = html;
+    Q_EMIT servedHtmlChanged();
+}
+
+QByteArray LoopbackServer::servedHtml() const
+{
+    Q_D(const LoopbackServer);
+    return d->m_servedHtml;
+}
+
+QUrl LoopbackServer::callbackUrl() const
+{
+    Q_D(const LoopbackServer);
+    if (!d->isListening())
+        return QUrl();
+    return QUrl(QString::fromLatin1("http://localhost:%1/").
+                arg(d->serverPort()));
+}
+
+#include "loopback-server.moc"

--- a/plugins/OnlineAccountsPlugin/loopback-server.h
+++ b/plugins/OnlineAccountsPlugin/loopback-server.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of libAuthentication
+ *
+ * Copyright (C) 2017-2020 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef OAP_LOOPBACK_SERVER_H
+#define OAP_LOOPBACK_SERVER_H
+
+#include "global.h"
+
+#include <QByteArray>
+#include <QObject>
+#include <QScopedPointer>
+#include <QUrl>
+
+namespace OnlineAccountsPlugin {
+
+class LoopbackServerPrivate;
+class OAP_EXPORT LoopbackServer: public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QUrl callbackUrl READ callbackUrl NOTIFY callbackUrlChanged)
+    Q_PROPERTY(QByteArray servedHtml READ servedHtml WRITE setServedHtml
+               NOTIFY servedHtmlChanged)
+    Q_PROPERTY(int portIncrementAttempts READ portIncrementAttempts
+               WRITE setPortIncrementAttempts
+               NOTIFY portIncrementAttemptsChanged)
+
+public:
+    LoopbackServer(QObject *parent = 0);
+    ~LoopbackServer();
+
+    Q_REQUIRED_RESULT bool listen(uint16_t port = 0);
+    void close();
+
+    bool isListening() const { return !callbackUrl().isEmpty(); }
+    uint16_t port() const;
+
+    void setPortIncrementAttempts(int maxAttempts);
+    int portIncrementAttempts() const;
+
+    void setServedHtml(const QByteArray &html);
+    QByteArray servedHtml() const;
+
+    QUrl callbackUrl() const;
+
+Q_SIGNALS:
+    void portIncrementAttemptsChanged();
+    void servedHtmlChanged();
+    void callbackUrlChanged();
+    void visited(const QUrl &url);
+
+private:
+    Q_DECLARE_PRIVATE(LoopbackServer)
+    QScopedPointer<LoopbackServerPrivate> d_ptr;
+};
+
+} // namespace
+
+#endif // OAP_LOOPBACK_SERVER_H

--- a/plugins/module/OAuth.qml
+++ b/plugins/module/OAuth.qml
@@ -30,6 +30,9 @@ Item {
     property var authenticationParameters: {}
     /* To override the default access control list: */
     property var accessControlList: ["unconfined"]
+    /* To override the request handler (useful for using an custom Web view or
+     * invoking the native browser): */
+    property var requestHandler: defaultRequestHandler
 
     property var authReply
     property bool isNewAccount: false
@@ -52,7 +55,7 @@ Item {
     }
 
     RequestHandler {
-        id: requestHandler
+        id: defaultRequestHandler
         onRequestChanged: {
             if (request) {
                 console.log("RequestHandler captured request!")

--- a/plugins/module/OAuth.qml
+++ b/plugins/module/OAuth.qml
@@ -51,7 +51,9 @@ Item {
     Component.onCompleted: {
         isNewAccount = (account.accountId === 0)
         enableAccount()
-        authenticate()
+        if (requestHandler == defaultRequestHandler) {
+            authenticate()
+        }
     }
 
     RequestHandler {

--- a/plugins/module/OAuth.qml
+++ b/plugins/module/OAuth.qml
@@ -22,7 +22,6 @@ import Ubuntu.Components.ListItems 1.3 as ListItem
 import Ubuntu.Components.Popups 1.3
 import Ubuntu.OnlineAccounts 0.1
 import Ubuntu.OnlineAccounts.Plugin 1.0
-import "."
 
 Item {
     id: root

--- a/plugins/module/module.pro
+++ b/plugins/module/module.pro
@@ -23,10 +23,12 @@ PKGCONFIG += \
 QMAKE_LFLAGS += $$QMAKE_LFLAGS_NOUNDEF
 
 SOURCES = \
-    plugin.cpp
+    plugin.cpp \
+    qml-loopback-server.cpp
 
 HEADERS += \
-    plugin.h
+    plugin.h \
+    qml-loopback-server.h
 
 INCLUDEPATH += \
     $$TOP_SRC_DIR/plugins

--- a/plugins/module/plugin.cpp
+++ b/plugins/module/plugin.cpp
@@ -21,6 +21,9 @@
  */
 
 #include "plugin.h"
+
+#include "qml-loopback-server.h"
+
 #include <OnlineAccountsPlugin/application-manager.h>
 #include <OnlineAccountsPlugin/request-handler.h>
 #include <QDebug>
@@ -44,4 +47,5 @@ void Plugin::registerTypes(const char *uri)
     qDebug() << Q_FUNC_INFO << uri;
 
     qmlRegisterType<SignOnUi::RequestHandler>(uri, 1, 0, "RequestHandler");
+    qmlRegisterType<QmlLoopbackServer>(uri, 1, 0, "LoopbackServer");
 }

--- a/plugins/module/qml-loopback-server.cpp
+++ b/plugins/module/qml-loopback-server.cpp
@@ -1,0 +1,147 @@
+/*
+ * This file is part of libAuthentication
+ *
+ * Copyright (C) 2017-2020 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#include "qml-loopback-server.h"
+
+#include <QDebug>
+
+using namespace OnlineAccountsPlugin;
+
+namespace OnlineAccountsPlugin {
+
+class QmlLoopbackServerPrivate: public QObject
+{
+    Q_OBJECT
+    Q_DECLARE_PUBLIC(QmlLoopbackServer)
+
+public:
+    QmlLoopbackServerPrivate(QmlLoopbackServer *q);
+    ~QmlLoopbackServerPrivate();
+
+    void queueUpdate();
+
+private Q_SLOTS:
+    void update();
+
+private:
+    bool m_updateQueued;
+    int m_port;
+    bool m_listening;
+    QmlLoopbackServer *q_ptr;
+};
+
+} // namespace
+
+QmlLoopbackServerPrivate::QmlLoopbackServerPrivate(QmlLoopbackServer *q):
+    m_port(0),
+    m_listening(true),
+    q_ptr(q)
+{
+}
+
+QmlLoopbackServerPrivate::~QmlLoopbackServerPrivate()
+{
+}
+
+void QmlLoopbackServerPrivate::queueUpdate()
+{
+    if (!m_updateQueued) {
+        QMetaObject::invokeMethod(this, "update", Qt::QueuedConnection);
+        m_updateQueued = true;
+    }
+}
+
+void QmlLoopbackServerPrivate::update()
+{
+    Q_Q(QmlLoopbackServer);
+
+    m_updateQueued = false;
+
+    bool nothingToDo = m_listening == q->isListening();
+    if (nothingToDo) return;
+
+    if (m_listening) {
+        if (q->listen(uint16_t(m_port))) {
+            uint16_t realPort = q->port();
+            if (realPort != m_port) {
+                Q_EMIT q->portChanged();
+            }
+        } else {
+            qWarning() << "Listening failed";
+        }
+    } else {
+        q->close();
+    }
+}
+
+QmlLoopbackServer::QmlLoopbackServer(QObject *parent):
+    LoopbackServer(parent),
+    d_ptr(new QmlLoopbackServerPrivate(this))
+{
+}
+
+QmlLoopbackServer::~QmlLoopbackServer()
+{
+}
+
+void QmlLoopbackServer::setPort(int port)
+{
+    Q_D(QmlLoopbackServer);
+    if (isListening()) {
+        qWarning() << "Cannot change port while already listening";
+        return;
+    }
+
+    if (port == d->m_port) return;
+    d->m_port = port;
+    d->queueUpdate();
+    Q_EMIT portChanged();
+}
+
+int QmlLoopbackServer::port() const
+{
+    Q_D(const QmlLoopbackServer);
+    return isListening() ? LoopbackServer::port() : d->m_port;
+}
+
+void QmlLoopbackServer::setListening(bool listening)
+{
+    Q_D(QmlLoopbackServer);
+
+    if (listening == d->m_listening) return;
+    d->m_listening = listening;
+
+    /* The change notification will be emitted when doing the update */
+    d->queueUpdate();
+}
+
+void QmlLoopbackServer::classBegin()
+{
+    Q_D(QmlLoopbackServer);
+    d->m_updateQueued = true;
+}
+
+void QmlLoopbackServer::componentComplete()
+{
+    Q_D(QmlLoopbackServer);
+    d->update();
+}
+
+#include "qml-loopback-server.moc"

--- a/plugins/module/qml-loopback-server.h
+++ b/plugins/module/qml-loopback-server.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of libAuthentication
+ *
+ * Copyright (C) 2017-2020 Alberto Mardegan <mardy@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef OAP_QML_LOOPBACK_SERVER_H
+#define OAP_QML_LOOPBACK_SERVER_H
+
+#include "OnlineAccountsPlugin/loopback-server.h"
+
+#include <QObject>
+#include <QQmlParserStatus>
+#include <QScopedPointer>
+
+namespace OnlineAccountsPlugin {
+
+class QmlLoopbackServerPrivate;
+class QmlLoopbackServer: public LoopbackServer, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+    Q_PROPERTY(int port READ port WRITE setPort NOTIFY portChanged)
+    Q_PROPERTY(bool listening READ isListening WRITE setListening
+               NOTIFY callbackUrlChanged)
+
+public:
+    QmlLoopbackServer(QObject *parent = 0);
+    ~QmlLoopbackServer();
+
+    void setPort(int port);
+    int port() const;
+
+    void setListening(bool isListening);
+
+    void classBegin() override;
+    void componentComplete() override;
+
+Q_SIGNALS:
+    void portChanged();
+    void callbackUrlChanged(); // to make the moc happy
+
+private:
+    Q_DECLARE_PRIVATE(QmlLoopbackServer)
+    QScopedPointer<QmlLoopbackServerPrivate> d_ptr;
+};
+
+} // namespace
+
+#endif // OAP_QML_LOOPBACK_SERVER_H

--- a/plugins/module/qmldir.in
+++ b/plugins/module/qmldir.in
@@ -1,5 +1,6 @@
 module $${API_URI}
 plugin $${TARGET}
+ErrorItem 1.0 ErrorItem.qml
 KeyboardRectangle 1.0 KeyboardRectangle.qml
 OAuthMain 1.0 OAuthMain.qml
 OAuth 1.0 OAuth.qml


### PR DESCRIPTION
This adds the LoopbackServer class, which will have to be used by the Google plugin, and the ExternalBrowserRequest handler which will be instantiated when the callback URL has `localhost` as its host. Once the loopback server has detected that the page has been visited, the account plugin will forward this information to the ExternalBrowserRequest, to deliver the result of the user interaction to the signon-oauth-plugin.

Note: you also need https://github.com/ubports/account-plugins/pull/45 in order to test this.
